### PR TITLE
Add no-arg constructor to Markdown and enhance null check in Starter

### DIFF
--- a/src/main/java/io/github/kloping/qqbot/Starter.java
+++ b/src/main/java/io/github/kloping/qqbot/Starter.java
@@ -134,7 +134,8 @@ public class Starter implements Runnable {
         contextManager.append(token, TOKEN_ID);
         if (Judge.isNotEmpty(config.getSecret()))
             contextManager.append(secret, SECRET_ID);
-        contextManager.append(getConfig().getCode(), INTENTS_ID);
+        if (Judge.isNotNull(getConfig().getCode()))
+          contextManager.append(getConfig().getCode(), INTENTS_ID);
         contextManager.append(new Integer[]{0, 1}, SHARD_ID);
         contextManager.append("Bot " + appid + "." + token, AUTH_ID);
         contextManager.append(getConfig().getReconnect(), RECONNECT_K_ID);

--- a/src/main/java/io/github/kloping/qqbot/entities/ex/Markdown.java
+++ b/src/main/java/io/github/kloping/qqbot/entities/ex/Markdown.java
@@ -43,6 +43,9 @@ public class Markdown implements SendAble {
         this.custom_template_id = custom_template_id;
     }
 
+    public Markdown() {
+    }
+
     public Markdown addParam(String key, String value) {
         if (params == null) params = new LinkedList<>();
         params.add(new Param(key, new String[]{value}));


### PR DESCRIPTION
1、在Markdown里增加无参构造器，发送markdown可以不需要使用模板，直接使用content进行发送
2、如果使用webhook模式，没有设置code，`starter.getConfig().setCode(Intents.PRIVATE_INTENTS.getCode());`会空指针异常，但是webhook模式不需要设置code