### PR TITLE
Add support for GROUP_MESSAGE_CREATE event handling in GroupEventsReg…

### DIFF
--- a/src/main/java/io/github/kloping/qqbot/impl/registers/GroupEventsRegister.java
+++ b/src/main/java/io/github/kloping/qqbot/impl/registers/GroupEventsRegister.java
@@ -17,10 +17,12 @@ import io.github.kloping.spt.interfaces.Logger;
 @Entity
 public class GroupEventsRegister implements Events.EventRegister {
     public static final String GROUP_AT_MESSAGE_CREATE = "GROUP_AT_MESSAGE_CREATE";
+    public static final String GROUP_MESSAGE_CREATE = "GROUP_MESSAGE_CREATE";
 
     @AutoStandAfter
     private void r4(Events events) {
         events.register(GROUP_AT_MESSAGE_CREATE, this);
+        events.register(GROUP_MESSAGE_CREATE, this);
     }
 
     @AutoStand
@@ -33,6 +35,8 @@ public class GroupEventsRegister implements Events.EventRegister {
     public Event handle(String t, JSONObject mateData, RawMessage message) {
         Event event = null;
         if (GROUP_AT_MESSAGE_CREATE.equals(t)) {
+            event = new BaseGroupMessageEvent(message, mateData, bot);
+        } else if (GROUP_MESSAGE_CREATE.equals(t)) {
             event = new BaseGroupMessageEvent(message, mateData, bot);
         } else {
         }


### PR DESCRIPTION
在webhook中支持 GROUP_MESSAGE_CREATE 事件
GROUP_MESSAGE_CREATE  为灰度事件，不需要用户at机器人即可收到。